### PR TITLE
BUGFIX: Prevent json parse error

### DIFF
--- a/Resources/Private/JavaScript/Terminal/src/helpers/fetchCommands.ts
+++ b/Resources/Private/JavaScript/Terminal/src/helpers/fetchCommands.ts
@@ -18,7 +18,7 @@ const fetchCommands = async (endPoint: string): Promise<{ success: boolean; resu
             if (!response.ok) {
                 return {
                     success: false,
-                    result: [],
+                    result: {},
                 };
             }
 
@@ -32,7 +32,7 @@ const fetchCommands = async (endPoint: string): Promise<{ success: boolean; resu
                     .catch((error: Error) => {
                         return {
                             success: false,
-                            result: [],
+                            result: {},
                         };
                     })
             );
@@ -41,7 +41,7 @@ const fetchCommands = async (endPoint: string): Promise<{ success: boolean; resu
             logToConsole('error', error.message);
             return {
                 success: false,
-                result: [],
+                result: {},
             };
         });
 };

--- a/Resources/Private/JavaScript/Terminal/src/helpers/fetchCommands.ts
+++ b/Resources/Private/JavaScript/Terminal/src/helpers/fetchCommands.ts
@@ -14,7 +14,29 @@ const fetchCommands = async (endPoint: string): Promise<{ success: boolean; resu
                 'Content-Type': 'application/json',
             },
         }))
-        .then((response: Response) => response && response.json())
+        .then((response: Response) => {
+            if (!response.ok) {
+                return {
+                    success: false,
+                    result: [],
+                };
+            }
+
+            return (
+                response &&
+                response
+                    .json()
+                    .then((data: CommandList) => {
+                        return data;
+                    })
+                    .catch((error: Error) => {
+                        return {
+                            success: false,
+                            result: [],
+                        };
+                    })
+            );
+        })
         .catch((error: Error) => {
             logToConsole('error', error.message);
             return {


### PR DESCRIPTION
Prevents the JSON encode error in the browser console.

Related: #15
