### PR TITLE
BUGFIX: Prevent error in console from getCommands

### DIFF
--- a/Classes/Controller/TerminalCommandController.php
+++ b/Classes/Controller/TerminalCommandController.php
@@ -77,7 +77,7 @@ class TerminalCommandController extends ActionController
      */
     protected $privilegeManager;
 
-    public function getCommandsAction(): void
+    protected function getAllowedCommands(): array
     {
         $commandNames = $this->terminalCommandService->getCommandNames();
 
@@ -85,6 +85,18 @@ class TerminalCommandController extends ActionController
             return $this->privilegeManager->isGranted(TerminalCommandPrivilege::class,
                 new TerminalCommandPrivilegeSubject($commandName));
         });
+        return $availableCommandNames;
+    }
+
+    public function checkCommandsAction(): void
+    {
+        $availableCommandNames = $this->getAllowedCommands();
+        $this->view->assign('value', ['success' => count($availableCommandNames) > 0]);
+    }
+
+    public function getCommandsAction(): void
+    {
+        $availableCommandNames = $this->getAllowedCommands();
 
         $commandDefinitions = array_reduce($availableCommandNames, function (array $carry, string $commandName) {
             $command = $this->terminalCommandService->getCommand($commandName);

--- a/Configuration/Policy.yaml
+++ b/Configuration/Policy.yaml
@@ -3,6 +3,10 @@ privilegeTargets:
     'Shel.Neos.Terminal:ExecuteCommands':
       matcher: 'method(Shel\Neos\Terminal\Controller\TerminalCommandController->(?!initialize).*Action())'
 
+    'Shel.Neos.Terminal:CheckCommands':
+      label: Permission to check available commands
+      matcher: 'method(Shel\Neos\Terminal\Controller\TerminalCommandController->checkCommandsAction())'
+
   'Shel\Neos\Terminal\Security\TerminalCommandPrivilege':
     'Shel.Neos.Terminal:Command.All':
       matcher: '*'
@@ -16,6 +20,11 @@ privilegeTargets:
       matcher: 'nodeRepair'
 
 roles:
+  'Neos.Flow:Everybody':
+    privileges:
+      -
+        privilegeTarget: 'Shel.Neos.Terminal:CheckCommands'
+        permission: GRANT
   'Shel.Neos.Terminal:TerminalUser':
     label: 'Terminal user'
     description: 'Grants access to run read-only eel and search terminal commands'

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -18,6 +18,7 @@ Neos:
             signature: ''
             showThankYouMessage: true
           getCommandsEndPoint: '/neos/shel-neos-terminal/getcommands'
+          checkCommandsEndPoint: '/neos/shel-neos-terminal/checkcommands'
           invokeCommandEndPoint: '/neos/shel-neos-terminal/invokecommand'
           theme:
             contentStyle:

--- a/Resources/Private/JavaScript/Terminal/src/Terminal.tsx
+++ b/Resources/Private/JavaScript/Terminal/src/Terminal.tsx
@@ -43,6 +43,7 @@ class Terminal extends React.PureComponent<TerminalProps> {
             <CommandsProvider
                 getCommandsEndPoint={config.getCommandsEndPoint}
                 invokeCommandEndPoint={config.invokeCommandEndPoint}
+                checkCommandsEndPoint={config.checkCommandsEndPoint}
                 siteNode={this.props.siteNode?.contextPath}
                 documentNode={this.props.documentNode?.contextPath}
                 focusedNode={this.props.focusedNodes?.length > 0 ? this.props.focusedNodes[0] : null}

--- a/Resources/Private/JavaScript/Terminal/src/helpers/checkCommands.ts
+++ b/Resources/Private/JavaScript/Terminal/src/helpers/checkCommands.ts
@@ -1,0 +1,24 @@
+// @ts-ignore
+import { fetchWithErrorHandling } from '@neos-project/neos-ui-backend-connector';
+
+const checkCommands = async (endpoint): Promise<{ success: boolean }> => {
+    try {
+        const response = await fetchWithErrorHandling
+            .withCsrfToken((csrfToken) => ({
+                url: endpoint,
+                method: 'GET',
+                credentials: 'include',
+                headers: {
+                    'X-Flow-Csrftoken': csrfToken,
+                    'Content-Type': 'application/json',
+                },
+            }));
+
+        return await response.json();
+    } catch (error) {
+        // Handle other errors here
+        return { success: false };
+    }
+};
+
+export default checkCommands;

--- a/Resources/Private/JavaScript/Terminal/src/helpers/fetchCommands.ts
+++ b/Resources/Private/JavaScript/Terminal/src/helpers/fetchCommands.ts
@@ -3,17 +3,29 @@ import { fetchWithErrorHandling } from '@neos-project/neos-ui-backend-connector'
 import { CommandList } from '../interfaces';
 
 const fetchCommands = async (endPoint): Promise<{ success: boolean; result: CommandList }> => {
-    return fetchWithErrorHandling
-        .withCsrfToken((csrfToken) => ({
-            url: endPoint,
-            method: 'GET',
-            credentials: 'include',
-            headers: {
-                'X-Flow-Csrftoken': csrfToken,
-                'Content-Type': 'application/json',
-            },
-        }))
-        .then((response) => response && response.json());
+    try {
+        const response = await fetchWithErrorHandling
+            .withCsrfToken((csrfToken) => ({
+                url: endPoint,
+                method: 'GET',
+                credentials: 'include',
+                headers: {
+                    'X-Flow-Csrftoken': csrfToken,
+                    'Content-Type': 'application/json',
+                },
+            }));
+
+        if (response.status === 403) {
+            // Handle 403 errors here
+            return { success: false, result: {} };
+        }
+
+        const result = await response.json();
+        return { success: true, result };
+    } catch (error) {
+        // Handle other errors here
+        return { success: false, result: {} };
+    }
 };
 
 export default fetchCommands;

--- a/Resources/Private/JavaScript/Terminal/src/provider/CommandsProvider.tsx
+++ b/Resources/Private/JavaScript/Terminal/src/provider/CommandsProvider.tsx
@@ -3,10 +3,12 @@ import { createContext, useCallback, useContext, useEffect, useState } from 'rea
 
 import { FeedbackEnvelope, I18nRegistry, CommandList, NodeContextPath } from '../interfaces';
 import fetchCommands from '../helpers/fetchCommands';
+import checkCommands from '../helpers/checkCommands';
 import doInvokeCommand from '../helpers/doInvokeCommand';
 
 interface CommandsContextProps {
     children: React.ReactElement;
+    checkCommandsEndPoint: string;
     getCommandsEndPoint: string;
     invokeCommandEndPoint: string;
     siteNode: NodeContextPath;
@@ -50,6 +52,7 @@ const logToConsole = (type = 'log', text: string, ...args) => {
 export const CommandsProvider = ({
     invokeCommandEndPoint,
     getCommandsEndPoint,
+    checkCommandsEndPoint,
     children,
     documentNode,
     focusedNode,
@@ -60,7 +63,12 @@ export const CommandsProvider = ({
     const [commands, setCommands] = useState<CommandList>({});
 
     useEffect(() => {
-        fetchCommands(getCommandsEndPoint).then(({ result }) => setCommands(result));
+        checkCommands(checkCommandsEndPoint).then(({ success }) => {
+            if (!success) {
+                return;
+            }
+            return fetchCommands(getCommandsEndPoint).then(({ result }) => setCommands(result));
+        });
     }, [getCommandsEndPoint, setCommands]);
 
     const translate = useCallback(

--- a/Resources/Private/JavaScript/Terminal/src/typings/global.d.ts
+++ b/Resources/Private/JavaScript/Terminal/src/typings/global.d.ts
@@ -7,6 +7,7 @@ interface Window {
 interface TerminalConfig {
     getCommandsEndPoint: string;
     invokeCommandEndPoint: string;
+    checkCommandsEndPoint: string;
     theme: TerminalTheme;
     welcomeMessage?: string;
 }


### PR DESCRIPTION
This update introduces an additional endpoint to verify the user's access to available commands. Since this endpoint is not limited to the Admin or TerminalUser roles, we have implemented a safeguard to handle unsuccessful requests.

Conversely, there is also an extra request to retrieve commands when the user is authorized to manage them.

Fixes: #15